### PR TITLE
fix: prevent duplicate model message push on import

### DIFF
--- a/go/imports/ai/model/model.go
+++ b/go/imports/ai/model/model.go
@@ -61,11 +61,12 @@ func (i *wacModel) Push(messages ...*types.Message) error {
 					Output:      toolResult.Output,
 				}))
 			}
-			msgs = append(msgs, witTypes.Message{
-				Role:    witTypes.Role(message.Role),
-				Content: cm.ToList(content),
-			})
 		}
+
+		msgs = append(msgs, witTypes.Message{
+			Role:    witTypes.Role(message.Role),
+			Content: cm.ToList(content),
+		})
 	}
 	result := i.m.Push(cm.ToList(msgs))
 	if result.IsErr() {


### PR DESCRIPTION
# Description

The append was on the content loop which was pushing a message for each content item within the message, resulting in duplicates.  Moved push outside of content loop.