### PR TITLE
fix: use global formatter, and format resource rep in model export

### DIFF
--- a/go/exports/ai/models/formatter.go
+++ b/go/exports/ai/models/formatter.go
@@ -18,10 +18,10 @@ type formatResourceTable struct {
 }
 
 func (f *formatResourceTable) constructor() model.Format {
-	defer func() {
-		f.rep++
-	}()
-	return model.FormatResourceNew(f.rep)
+	value := model.FormatResourceNew(f.rep)
+	f.resources[f.rep] = formatter
+	f.rep++
+	return value
 }
 
 func (f *formatResourceTable) destructor(self cm.Rep) {


### PR DESCRIPTION
# Description

Fixes problem causing agent invoke errors as the model was not correctly using the format resource rep when accessing the format functions. This fix allows both model and format to individually track their resource ids.