### PR TITLE
fix: tool capability type return type reinterpret

### DIFF
--- a/go/hayride/ai/tools/tools.go
+++ b/go/hayride/ai/tools/tools.go
@@ -39,6 +39,6 @@ func (t Toolbox) Capabilities() ([]types.ToolSchema, error) {
 		return nil, fmt.Errorf("failed to get capabilities: %s", result.Err().Data())
 	}
 
-	schemas := cm.Reinterpret[cm.List[types.ToolSchema]](result.OK())
-	return schemas.Slice(), nil
+	schemas := result.OK().Slice()
+	return cm.Reinterpret[[]types.ToolSchema](schemas), nil
 }


### PR DESCRIPTION
# Description

Reinterpret of `cm.List[witTools.ToolSchema]` as `cm.List[types.ToolSchema]` was failing in the tools Capability function.

Fixed by unwrapping the cm.List to slice first then doing reinterpret on the types.